### PR TITLE
Heavenisaplaceonearth1 fill percent patch

### DIFF
--- a/Patches/Security/Patch_Security.xml
+++ b/Patches/Security/Patch_Security.xml
@@ -497,8 +497,7 @@
 			<!-- ========== fillpercent replacement ========== -->
 
 			<li Class="PatchOperationReplace">
-			          <xpath>/Defs/ThingDef[
-					defName="Turret_MC" or
+		          	<xpath>/Defs/ThingDef[
 					defName="NestMissile" or
 					defName="NestHMG" or
 					defName="NestAGS" or
@@ -508,10 +507,17 @@
 					defName="SuvTurret" or
 					defName="WaveEmitter" or
 					defName="RSDummy"
-				  ]/fillPercent</xpath>
-			          <value>
+				]/fillPercent</xpath>
+				<value>
 			            <fillPercent>0.85</fillPercent>
-			          </value>
+			  	</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[@Name = "BaseMCBuilding"]/fillPercent</xpath>
+				<value>
+					<fillPercent>0.85</fillPercent>
+				</value>
 			</li>
 
 			<!-- ========== Impact Mine ========== -->


### PR DESCRIPTION
-changed fillpercent of turrets to .85 so that their height would be 1.49 m, allowing them to shoot through embrasures.

-changed fillpercent of BaseMCBuilding to .85 so that height of the Molten Core turret would be 1.49 m, allowing it to shoot through embrasures.