### PR TITLE
Updated armor patch for Rimsenal 1.2

### DIFF
--- a/Patches/Core/Apparel_RS_CE.xml
+++ b/Patches/Core/Apparel_RS_CE.xml
@@ -52,7 +52,7 @@
 			<!-- ========== Pioneer Armor =========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Laconian"]/statBases</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases</xpath>
 				<value>
 					<Bulk>100</Bulk>
 					<WornBulk>15</WornBulk>
@@ -60,35 +60,35 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Laconian"]/statBases/Mass</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/Mass</xpath>
 				<value>
 					<Mass>60</Mass>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Laconian"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>22</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Laconian"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>40</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Laconian"]/costList</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/costList</xpath>
 				<value>
 					<DevilstrandCloth>20</DevilstrandCloth>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Laconian"]/equippedStatOffsets</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/equippedStatOffsets</xpath>
 				<value>
 					<CarryWeight>40</CarryWeight>
 					<CarryBulk>10</CarryBulk>
@@ -96,7 +96,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Laconian"]/apparel/bodyPartGroups</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerArmor"]/apparel/bodyPartGroups</xpath>
 				<value>
 					<li>Hands</li>
 					<li>Feet</li>
@@ -107,7 +107,7 @@
 			<!-- ========== Pioneer Helmet =========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_LaconianH"]/statBases</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases</xpath>
 				<value>
 					<Bulk>5</Bulk>
 					<WornBulk>1</WornBulk>
@@ -115,21 +115,21 @@
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_LaconianH"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_LaconianH"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>36</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_LaconianH"]/equippedStatOffsets</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_PioneerH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
@@ -205,24 +205,24 @@
 				</value>
 			</li>
 			
-			<!-- ========== Nervesuit =========== -->
+			<!-- ========== Strikesuit =========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Nervesuit"]/statBases</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases</xpath>
 				<value>
 					<Bulk>12</Bulk>
 					<WornBulk>3.0</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Nervesuit"]/apparel/bodyPartGroups</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/apparel/bodyPartGroups</xpath>
 				<value>
 					<li>Hands</li>
 					<li>Feet</li>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Nervesuit"]/equippedStatOffsets</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/equippedStatOffsets</xpath>
 				<value>
 					<CarryWeight>10</CarryWeight>
 					<CarryBulk>5</CarryBulk>
@@ -230,44 +230,44 @@
 			</li>
 			
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Nervesuit"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>12</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Dropsuit"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_Strikesuit"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>26</ArmorRating_Blunt>
 				</value>
 			</li>			
 			
-			<!-- ========== Nervesuit helmet =========== -->
+			<!-- ========== Strikesuit helmet =========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_NervesuitH"]/statBases</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_StrikesuitH"]/statBases</xpath>
 				<value>
 					<Bulk>3</Bulk>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_NervesuitH"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_StrikesuitH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>10</ArmorRating_Sharp>
 				</value>
 			</li>
 
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_NervesuitH"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_StrikesuitH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>22</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_NervesuitH"]/equippedStatOffsets</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_StrikesuitH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
@@ -276,39 +276,39 @@
 			<!-- ========== Assault Armor =========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Bjorn"]/statBases</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases</xpath>
 				<value>
 					<Bulk>80</Bulk>
 					<WornBulk>20</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Bjorn"]/statBases/Mass</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases/Mass</xpath>
 				<value>
 					<Mass>60</Mass>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Bjorn"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>28</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Bjorn"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>60</ArmorRating_Blunt>
 				</value>
 			</li>			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Bjorn"]/equippedStatOffsets</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/equippedStatOffsets</xpath>
 				<value>
 					<CarryWeight>90</CarryWeight>
 					<CarryBulk>10</CarryBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Bjorn"]/apparel/bodyPartGroups</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmor"]/apparel/bodyPartGroups</xpath>
 				<value>
 					<li>Hands</li>
 					<li>Feet</li>
@@ -318,27 +318,27 @@
 			<!-- ========== Assault Helmet =========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_BjornH"]/statBases</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases</xpath>
 				<value>
 					<Bulk>8</Bulk>
 					<WornBulk>2</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_BjornH"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_BjornH"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>40</ArmorRating_Blunt>
 				</value>
 			</li>
 			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_BjornH"]/equippedStatOffsets</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_AssaultArmorH"]/equippedStatOffsets</xpath>
 				<value>
 					<SmokeSensitivity>-1</SmokeSensitivity>
 				</value>
@@ -417,38 +417,38 @@
 			<!-- ========== Reflactor Carapace =========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Nemesis"]/statBases</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases</xpath>
 				<value>
 					<Bulk>100</Bulk>
 					<WornBulk>15</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Nemesis"]/statBases/Mass</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases/Mass</xpath>
 				<value>
 					<Mass>50</Mass>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Nemesis"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Nemesis"]/statBases/ArmorRating_Heat</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases/ArmorRating_Heat</xpath>
 				<value>
 					<ArmorRating_Heat>10</ArmorRating_Heat>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_Nemesis"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>42</ArmorRating_Blunt>
 				</value>
 			</li>			
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Nemesis"]/equippedStatOffsets</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/equippedStatOffsets</xpath>
 				<value>
 					<CarryWeight>40</CarryWeight>
 					<CarryBulk>10</CarryBulk>
@@ -456,7 +456,7 @@
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_Nemesis"]/apparel/bodyPartGroups</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmor"]/apparel/bodyPartGroups</xpath>
 				<value>
 					<li>Hands</li>
 					<li>Feet</li>
@@ -466,33 +466,33 @@
 			<!-- ========== Reflactor Helmet =========== -->
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_NemesisH"]/statBases</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases</xpath>
 				<value>
 					<Bulk>5</Bulk>
 					<WornBulk>1.1</WornBulk>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_NemesisH"]/statBases/ArmorRating_Sharp</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>18</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_NemesisH"]/statBases/ArmorRating_Heat</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases/ArmorRating_Heat</xpath>
 				<value>
 					<ArmorRating_Heat>10</ArmorRating_Heat>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/thingDef[defName="Apparel_NemesisH"]/statBases/ArmorRating_Blunt</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>35</ArmorRating_Blunt>
 				</value>
 			</li>
 
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/thingDef[defName="Apparel_NemesisH"]</xpath>
+				<xpath>Defs/thingDef[defName="Apparel_ReflactorArmorH"]</xpath>
 				<value>
 					<equippedStatOffsets>
 						<SmokeSensitivity>-1</SmokeSensitivity>


### PR DESCRIPTION
Updated defnames which caused Rimsenal Armor patches to fail.  Brought them in line with newest Rimsenal update.

